### PR TITLE
Added map tint & flash shader

### DIFF
--- a/graphics/shaders/map_tint_flash.gdshader
+++ b/graphics/shaders/map_tint_flash.gdshader
@@ -1,0 +1,17 @@
+shader_type canvas_item;
+render_mode blend_mix;
+
+uniform vec4 tone : source_color;
+uniform vec4 color : source_color;
+const vec3 lumaF = vec3(0.299, 0.587, 0.114);
+
+void fragment() {
+	vec4 frag = texture(TEXTURE, UV);
+	vec3 colorBlending = mix(frag.rgb, color.rgb, vec3(color.a));
+	float grayScale = dot(lumaF, frag.rgb);
+	vec3 colorAndGrayBlending = mix(colorBlending, vec3(grayScale), vec3(tone.a));
+	vec3 toneAndColorBlending = tone.rgb + colorAndGrayBlending;
+
+	COLOR.rgb = toneAndColorBlending;
+	COLOR.a = frag.a * COLOR.a;
+}

--- a/graphics/shaders/map_tint_flash.tres
+++ b/graphics/shaders/map_tint_flash.tres
@@ -1,0 +1,8 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://bb1xgnoyfsxeu"]
+
+[ext_resource type="Shader" path="res://graphics/shaders/map_tint_flash.gdshader" id="1_t1k2j"]
+
+[resource]
+shader = ExtResource("1_t1k2j")
+shader_parameter/tone = Color(0, 0, 0, 0)
+shader_parameter/color = Color(0, 0, 0, 0)

--- a/project.godot
+++ b/project.godot
@@ -14,6 +14,14 @@ config/name="Godotmon Project"
 config/features=PackedStringArray("4.3", "Mobile")
 config/icon="res://icon.svg"
 
+[display]
+
+window/size/viewport_width=320
+window/size/viewport_height=180
+window/size/initial_position_type=3
+window/stretch/mode="viewport"
+window/stretch/scale_mode="integer"
+
 [rendering]
 
 renderer/rendering_method="mobile"


### PR DESCRIPTION
This adds the standard RGSS shader used to apply tone and flash color to the map viewport.

How to use:
1. Create a Sprite2D instance with a subviewport texture and `map_tint_flash.tres` as material
2. Add stuff to render to the subviewport texture
3. In a script, get `$Sprite2D.material`, set the `tone` or `color` shader uniforms to the desired values.

Note: Godot uses values between 0 & 1 instead of between 0 & 255.