### PR TITLE
Added map_meta resource

### DIFF
--- a/src/global_scripts/global_constants.gd
+++ b/src/global_scripts/global_constants.gd
@@ -12,6 +12,20 @@ class_name Constants
 ## Size of a tile in pixels. Assumes tiles are square.
 const TILE_SIZE : int = 16
 
+## The type of map the player is in. Used in [MapMeta] to determine which kind of map panel a map is associated with.
+enum MapType {
+	GRASSY_OUTDOOR,
+	ROCKY_OUTDOOR,
+	SANDY_OUTDOOR,
+	SNOWY_OUTDOOR,
+	SEA,
+	SEA_SHORE,
+	CITY,
+	CAVERN,
+	FROZEN_CAVERN,
+	BUILDING
+}
+
 #endregion
 
 #region MONSTERS

--- a/src/resources/map_meta_resource.gd
+++ b/src/resources/map_meta_resource.gd
@@ -1,0 +1,19 @@
+extends Resource
+class_name MapMeta
+
+
+## All the meta about a specific map
+##
+## @tutorial: https://github.com/Maruno17/godotmon-project/wiki/Data-types#mapmeta
+
+
+## Path to the scene to load when the map is active
+@export_file("*.tscn") var scene : String
+## Key used to retrieve the name of the map in the text data
+@export var name_key : StringName
+## Value used to guess which kind of map panel to show when player enters the map
+@export var map_type : Constants.MapType
+## Position of the map in the world it's in
+@export var position : Vector2i
+## List of encounter group the map shows when loaded an primary
+#@export var encounter_table : Array[WildEncounterGroup]

--- a/src/resources/map_meta_resource.gd.uid
+++ b/src/resources/map_meta_resource.gd.uid
@@ -1,0 +1,1 @@
+uid://lhbmx3cq8p64


### PR DESCRIPTION
Added a temporary version of MapMeta without the encounter_table field as the WildEncouterGroup resource hasn't been defined yet.

I also made a new enum called MapType for the map_type field, but I don't really know if it should stay that way.

Finally, I decided to not follow the wiki and make the position a Vector2i instead of a Vector2 as I don't see why you'd need floats for the position of the map in the world.